### PR TITLE
Update pipenv install

### DIFF
--- a/run_ansible.sh
+++ b/run_ansible.sh
@@ -115,9 +115,34 @@ pipenv_init() {
       rm /tmp/get-pipenv.py
     fi
 
-    wget https://raw.githubusercontent.com/kennethreitz/pipenv/master/get-pipenv.py --directory /tmp
-    sudo python /tmp/get-pipenv.py
-    exit
+    case "$(uname -s)" in
+
+      Darwin)
+        echo 'Mac OS X'
+        brew install pipenv
+        ;;
+
+      Linux)
+        echo 'Linux'
+        if [ "$(which apt)" != "" ]; then
+          apt update
+          apt install -y python3-pip
+          pip3 install pipenv || exit 1
+        elif [ "$(which dnf)" != "" ]; then
+          dnf install -y pipenv
+        fi
+        ;;
+
+      CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        echo 'MS Windows'
+        ;;
+
+      *)
+        echo 'Other OS' 
+        echo "Could not detect OS, failing out.."
+        exit 1
+        ;;
+    esac
   fi
 
   if [[ pipfile_symlink == 'ENABLED' ]]; then

--- a/run_ansible.sh
+++ b/run_ansible.sh
@@ -116,7 +116,6 @@ pipenv_init() {
     fi
 
     case "$(uname -s)" in
-
       Darwin)
         echo 'Mac OS X'
         brew install pipenv
@@ -131,10 +130,6 @@ pipenv_init() {
         elif [ "$(which dnf)" != "" ]; then
           dnf install -y pipenv
         fi
-        ;;
-
-      CYGWIN*|MINGW32*|MSYS*|MINGW*)
-        echo 'MS Windows'
         ;;
 
       *)


### PR DESCRIPTION
Suggested route for installing pipenv appears to be using brew/apt/dnf, as referenced here: https://hub.docker.com/r/kennethreitz/pipenv/ and https://github.com/pypa/pipenv

Update commands on a per platform basis
